### PR TITLE
Force port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pomdok:
   projects:
     - domain: 'api.project'
       path: '/apps/api'
+      port: 9990
     - domain: 'www.project'
       path: '/apps/front'
     - domain: 'admin.project'
@@ -37,6 +38,8 @@ pomdok:
 ```
 
 You'll need at least `tld` field and one project to have a valid configuration.
+
+For each "project" you have, you'll need atleast a `domain` and `port` fields. `port` field is optional and used to force a given port for your webserver.
 
 To init `pomdok` for your project run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pomdok:
 
 You'll need at least `tld` field and one project to have a valid configuration.
 
-For each "project" you have, you'll need atleast a `domain` and `port` fields. `port` field is optional and used to force a given port for your webserver.
+For each "project" you have, you'll need at least a `domain` and `port` fields. `port` field is optional and used to force a given port for your webserver.
 
 To init `pomdok` for your project run:
 ```bash

--- a/generics.go
+++ b/generics.go
@@ -1,11 +1,13 @@
 package main
 
-type SymfonyJsonProxy struct {
+// SymfonyJSONProxy is a representation of Symfony CLI's configuration file
+type SymfonyJSONProxy struct {
 	Tld     string            `json:"tld"`
 	Port    int               `json:"port"`
 	Domains map[string]string `json:"domains"`
 }
 
+// PomdokYamlConfig is a representation of Pomdok's configuration file
 type PomdokYamlConfig struct {
 	Pomdok struct {
 		Tld      string

--- a/generics.go
+++ b/generics.go
@@ -5,6 +5,7 @@ type SymfonyJSONProxy struct {
 	Tld     string            `json:"tld"`
 	Port    int               `json:"port"`
 	Domains map[string]string `json:"domains"`
+	Ports   map[string]int    `json:"ports"`
 }
 
 // PomdokYamlConfig is a representation of Pomdok's configuration file
@@ -14,6 +15,7 @@ type PomdokYamlConfig struct {
 		Projects []struct {
 			Domain string `yaml:"domain"`
 			Path   string `yaml:"path"`
+			Port   int    `yaml:"port"`
 		}
 	}
 }

--- a/initCommand.go
+++ b/initCommand.go
@@ -28,7 +28,12 @@ var initCommand = &cli.Command{
 		printHeader()
 
 		argv := ctx.Argv().(*initT)
-		config, baseDirectory, _ := loadPomdokConfig(argv.Config)
+		config, baseDirectory, err := loadPomdokConfig(argv.Config)
+		if nil != err {
+			fmt.Println(err)
+			return nil
+		}
+
 		if config.Pomdok.Tld == "" {
 			fmt.Printf("Configuration file error 🙊. Maybe you should give a %s to your domains 🧐\n", yellow("tld"))
 			return nil

--- a/initCommand.go
+++ b/initCommand.go
@@ -69,12 +69,12 @@ var initCommand = &cli.Command{
 			fileDomains[element.Domain] = fullPath
 		}
 
-		symfonyJsonData := SymfonyJsonProxy{
+		symfonyJSONData := SymfonyJSONProxy{
 			Tld:     config.Pomdok.Tld,
 			Port:    7080,
 			Domains: fileDomains,
 		}
-		symfonyJson, _ := json.MarshalIndent(symfonyJsonData, "", "  ")
+		symfonyJSON, _ := json.MarshalIndent(symfonyJSONData, "", "  ")
 
 		currentUser, _ := user.Current()
 
@@ -84,14 +84,14 @@ var initCommand = &cli.Command{
 			return nil
 		}
 
-		symfonyDirUserUid := fmt.Sprint((info.Sys().(*syscall.Stat_t)).Uid)
-		symfonyDirUser, _ := user.LookupId(symfonyDirUserUid)
+		symfonyDirUserUID := fmt.Sprint((info.Sys().(*syscall.Stat_t)).Uid)
+		symfonyDirUser, _ := user.LookupId(symfonyDirUserUID)
 		if symfonyDirUser.Username != currentUser.Username {
 			fmt.Printf("Permission error 🙊. Directory ~/.symfony is owned by %s, please use: 'sudo chown -R %s ~/.symfony' 🧐\n", yellow(symfonyDirUser.Username), currentUser.Username)
 			return nil
 		}
 
-		ioutil.WriteFile(fmt.Sprintf("%s/.symfony/proxy.json", currentUser.HomeDir), symfonyJson, 0644)
+		ioutil.WriteFile(fmt.Sprintf("%s/.symfony/proxy.json", currentUser.HomeDir), symfonyJSON, 0644)
 		fmt.Printf("Project setup done ✔\n")
 
 		return nil

--- a/rootCommand.go
+++ b/rootCommand.go
@@ -13,7 +13,7 @@ type appT struct {
 
 var app = appT{
 	"pomdok",
-	"v1.0.0",
+	"v1.1.0",
 }
 
 func sprintHeader() string {

--- a/startAndStopCommand.go
+++ b/startAndStopCommand.go
@@ -38,7 +38,7 @@ var stopCommand = &cli.Command{
 	Fn: func(ctx *cli.Context) error {
 		printHeader()
 		startOrStopCommand("local:server:stop", "stopped 🛑")
-		runCommand("/usr/local/bin/symfony proxy:stop")
+		runCommand("symfony proxy:stop")
 
 		return nil
 	},
@@ -46,7 +46,7 @@ var stopCommand = &cli.Command{
 
 func startOrStopCommand(command string, message string) {
 	if false == symfonyProxyRunning() {
-		runCommand("/usr/local/bin/symfony proxy:start")
+		runCommand("symfony proxy:start")
 		fmt.Print("Started Symfony proxy server 👮\n")
 	}
 
@@ -63,10 +63,10 @@ func startOrStopCommand(command string, message string) {
 
 	for domain, path := range symfonyJSONData.Domains {
 		forcedPort := symfonyJSONData.Ports[domain]
-		formattedCommand := fmt.Sprintf("/usr/local/bin/symfony %s --dir=%s", command, path)
+		formattedCommand := fmt.Sprintf("symfony %s --dir=%s", command, path)
 
 		if "local:server:start --daemon" == command && 0 != forcedPort {
-			formattedCommand = fmt.Sprintf("/usr/local/bin/symfony %s --port=%d --dir=%s", command, forcedPort, path)
+			formattedCommand = fmt.Sprintf("symfony %s --port=%d --dir=%s", command, forcedPort, path)
 		}
 
 		runCommand(formattedCommand)

--- a/startAndStopCommand.go
+++ b/startAndStopCommand.go
@@ -62,7 +62,13 @@ func startOrStopCommand(command string, message string) {
 	json.Unmarshal(file, &symfonyJSONData)
 
 	for domain, path := range symfonyJSONData.Domains {
-		runCommand(fmt.Sprintf("/usr/local/bin/symfony %s --dir=%s", command, path))
+		forcedPort := symfonyJSONData.Ports[domain]
+		formattedCommand := fmt.Sprintf("/usr/local/bin/symfony %s --dir=%s", command, path)
+		if "local:server:start --daemon" == command && 0 != forcedPort {
+			formattedCommand = fmt.Sprintf("/usr/local/bin/symfony %s --port=%d --dir=%s", command, forcedPort, path)
+		}
+
+		runCommand(formattedCommand)
 		fmt.Printf("%s %s\n", message, yellow(fmt.Sprintf("%s.%s", domain, symfonyJSONData.Tld)))
 	}
 

--- a/startAndStopCommand.go
+++ b/startAndStopCommand.go
@@ -58,12 +58,12 @@ func startOrStopCommand(command string, message string) {
 	}
 	file, _ := ioutil.ReadFile(symfonyProxyConfigPah)
 
-	symfonyJsonData := SymfonyJsonProxy{}
-	json.Unmarshal(file, &symfonyJsonData)
+	symfonyJSONData := SymfonyJSONProxy{}
+	json.Unmarshal(file, &symfonyJSONData)
 
-	for domain, path := range symfonyJsonData.Domains {
+	for domain, path := range symfonyJSONData.Domains {
 		runCommand(fmt.Sprintf("/usr/local/bin/symfony %s --dir=%s", command, path))
-		fmt.Printf("%s %s\n", message, yellow(fmt.Sprintf("%s.%s", domain, symfonyJsonData.Tld)))
+		fmt.Printf("%s %s\n", message, yellow(fmt.Sprintf("%s.%s", domain, symfonyJSONData.Tld)))
 	}
 
 	return

--- a/startAndStopCommand.go
+++ b/startAndStopCommand.go
@@ -64,6 +64,7 @@ func startOrStopCommand(command string, message string) {
 	for domain, path := range symfonyJSONData.Domains {
 		forcedPort := symfonyJSONData.Ports[domain]
 		formattedCommand := fmt.Sprintf("/usr/local/bin/symfony %s --dir=%s", command, path)
+
 		if "local:server:start --daemon" == command && 0 != forcedPort {
 			formattedCommand = fmt.Sprintf("/usr/local/bin/symfony %s --port=%d --dir=%s", command, forcedPort, path)
 		}


### PR DESCRIPTION
Fixes #2 

Will allow to force port in your configuration file as following :point_down: 
```yaml
pomdok:
  tld: 'test'
  projects:
    - domain: 'api.project'
      path: '/apps/api'
      port: 9990
```