### PR TITLE
support symfony-cli v5 and earlier versions

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -4,6 +4,7 @@ package main
 type SymfonyJSONProxy struct {
 	Tld     string            `json:"tld"`
 	Port    int               `json:"port"`
+	Host    string            `json:"host"`
 	Domains map[string]string `json:"domains"`
 	Ports   map[string]int    `json:"ports"`
 }

--- a/initCommand.go
+++ b/initCommand.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path"
 	"strings"
-	"syscall"
 
 	"github.com/mkideal/cli"
 	"gopkg.in/yaml.v2"
@@ -73,27 +71,19 @@ var initCommand = &cli.Command{
 		symfonyJSONData := SymfonyJSONProxy{
 			Tld:     config.Pomdok.Tld,
 			Port:    7080,
+			Host:    "localhost",
 			Domains: fileDomains,
 			Ports:   filePorts,
 		}
 		symfonyJSON, _ := json.MarshalIndent(symfonyJSONData, "", "  ")
 
-		currentUser, _ := user.Current()
-
-		info, err := os.Stat(fmt.Sprintf("%s/.symfony", currentUser.HomeDir))
-		if os.IsNotExist(err) {
-			fmt.Printf("Symfony Binary not installed 🙊. Please use %s to see what you should do 🧐\n", yellow("symfony check"))
+		configPath := getSymfonyCliConfigPath()
+		if configPath == "" {
+			fmt.Printf("Symfony Binary not installed 🙊. Please use %s to see what you should do 🧐\n", yellow("symfony check:requirements"))
 			return nil
 		}
 
-		symfonyDirUserUID := fmt.Sprint((info.Sys().(*syscall.Stat_t)).Uid)
-		symfonyDirUser, _ := user.LookupId(symfonyDirUserUID)
-		if symfonyDirUser.Username != currentUser.Username {
-			fmt.Printf("Permission error 🙊. Directory ~/.symfony is owned by %s, please use: 'sudo chown -R %s ~/.symfony' 🧐\n", yellow(symfonyDirUser.Username), currentUser.Username)
-			return nil
-		}
-
-		ioutil.WriteFile(fmt.Sprintf("%s/.symfony/proxy.json", currentUser.HomeDir), symfonyJSON, 0644)
+		ioutil.WriteFile(fmt.Sprintf("%s/proxy.json", configPath), symfonyJSON, 0644)
 		fmt.Printf("Project setup done ✔\n")
 
 		return nil

--- a/installCommand.go
+++ b/installCommand.go
@@ -59,7 +59,7 @@ func linuxInstall() {
 }
 
 func darwinInstall() {
-	phpInstall("brew install php72 nss")
+	phpInstall("brew install php nss")
 	symfonyCliInstall()
 
 	return
@@ -88,8 +88,9 @@ func symfonyCliInstall() {
 	exists, _ := checkBinaryExists("symfony")
 	if exists == false {
 		fmt.Printf("Starting %s installation 🏃\n", yellow("symfony"))
-		runCommand("wget https://get.symfony.com/cli/installer -O - | bash")
-		runCommand("mv $HOME/.symfony/bin/symfony /usr/local/bin/")
+
+		runCommand("brew install symfony-cli")
+		runCommand("symfony version")
 
 		exists, _ = checkBinaryExists("symfony")
 		if exists == false {
@@ -99,10 +100,11 @@ func symfonyCliInstall() {
 
 		currentUser, _ := user.Current()
 		username := currentUser.Username
+		configPath := getSymfonyCliConfigPath()
 		if runtime.GOOS == "darwin" {
-			runCommand(fmt.Sprintf("sudo chown -R %s:staff ~/.symfony", username))
+			runCommand(fmt.Sprintf("sudo chown -R %s:staff %s", username, configPath))
 		} else {
-			runCommand(fmt.Sprintf("sudo chown -R %s:%s ~/.symfony", username, username))
+			runCommand(fmt.Sprintf("sudo chown -R %s:%s %s", username, username, configPath))
 		}
 
 		fmt.Printf("%s installed ✔\n", yellow("symfony"))

--- a/startAndStopCommand.go
+++ b/startAndStopCommand.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"os/user"
 
 	"github.com/mkideal/cli"
 )
@@ -50,13 +49,12 @@ func startOrStopCommand(command string, message string) {
 		fmt.Print("Started Symfony proxy server 👮\n")
 	}
 
-	user, _ := user.Current()
-	symfonyProxyConfigPah := fmt.Sprintf("%s/.symfony/proxy.json", user.HomeDir)
-	if _, err := os.Stat(symfonyProxyConfigPah); os.IsNotExist(err) {
+	symfonyProxyConfigPath := fmt.Sprintf("%s/proxy.json", getSymfonyCliConfigPath())
+	if _, err := os.Stat(symfonyProxyConfigPath); os.IsNotExist(err) {
 		fmt.Printf("Symfony proxy configuration does not exists 🙊. Maybe you should run %s before %s ? 🧐\n", yellow("init"), yellow("start"))
 		return
 	}
-	file, _ := ioutil.ReadFile(symfonyProxyConfigPah)
+	file, _ := ioutil.ReadFile(symfonyProxyConfigPath)
 
 	symfonyJSONData := SymfonyJSONProxy{}
 	json.Unmarshal(file, &symfonyJSONData)

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"os/user"
 	"strings"
+	"syscall"
 
 	"github.com/fatih/color"
 )
@@ -28,4 +33,41 @@ func runCommand(command string) {
 	exec.Command("sh", "-c", command).Run()
 
 	return
+}
+
+func getSymfonyCliConfigPath() string {
+	currentUser, _ := user.Current()
+	pathForSymfonyCli5 := fmt.Sprintf("%s/.symfony5", currentUser.HomeDir)
+	pathForSymfonyCliOld := fmt.Sprintf("%s/.symfony", currentUser.HomeDir)
+	path := ""
+
+	if _, err := os.Stat(pathForSymfonyCli5); err == nil {
+		path = pathForSymfonyCli5
+	} else if errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(pathForSymfonyCliOld); err == nil {
+			path = pathForSymfonyCliOld
+		} else if errors.Is(err, os.ErrNotExist) {
+			path = ""
+		} else {
+			exitWithMessage(fmt.Sprintf("Unexpected error while checking for the existence of %s. Error: %v\n", pathForSymfonyCliOld, err))
+		}
+	} else {
+		exitWithMessage(fmt.Sprintf("Unexpected error while checking for the existence of %s. Error: %v\n", pathForSymfonyCli5, err))
+	}
+
+	if path != "" {
+		info, _ := os.Stat(path)
+		symfonyDirUserUID := fmt.Sprint((info.Sys().(*syscall.Stat_t)).Uid)
+		symfonyDirUser, _ := user.LookupId(symfonyDirUserUID)
+		if symfonyDirUser.Username != currentUser.Username {
+			exitWithMessage(fmt.Sprintf("Permission error 🙊. Directory %s is owned by %s, please use: 'sudo chown -R %s %s' 🧐\n", path, yellow(symfonyDirUser.Username), currentUser.Username, path))
+		}
+	}
+
+	return path
+}
+
+func exitWithMessage(message string) {
+	fmt.Fprint(os.Stderr, message)
+	os.Exit(1)
 }


### PR DESCRIPTION
The function getSymfonyCliConfigPath checks for the existence of `~/.symfony5`, and then for that of `~/.symfony` as a fallback.

Reworded the recommendation to use `symfony check` since v5 of the tool autocompletes that command to an unrelated command and leads to an error.